### PR TITLE
Note kwags for mdadm in state

### DIFF
--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -63,6 +63,9 @@ def present(name,
 
     devices
         A list of devices used to build the array.
+    
+    kwargs
+        Optional arguments to be passed to mdadm.
 
     Example:
 


### PR DESCRIPTION
already documented in module, just copy over, documentation change only.